### PR TITLE
Fix: Pos print permissions and migration

### DIFF
--- a/app/Http/Livewire/Pos/Cart/Cart.php
+++ b/app/Http/Livewire/Pos/Cart/Cart.php
@@ -234,7 +234,6 @@ class Cart extends Component
             $invoice->seller_id = $currentSeller->id;
             $invoice->items_data = $order_items;
             $invoice->invoice_type_id = $invoiceType->id;
-            $invoice->tax_type = '';
             $invoice->invoice_date = now();
             $invoice->save();
 

--- a/app/Http/Livewire/Pos/Pos.php
+++ b/app/Http/Livewire/Pos/Pos.php
@@ -26,7 +26,12 @@ class Pos extends Component
 
     public function mount()
     {
-        $this->seller = Seller::where('user_id', backpack_user()->id)->firstOrFail();
+        $this->seller = Seller::where('user_id', backpack_user()->id)->first();
+
+        if (is_null($this->seller) || $this->seller->is_approved !== $this->seller::REVIEW_STATUS_APPROVED) {
+            abort(403);
+        }
+
         $this->setView('productList');
     }
 


### PR DESCRIPTION
- [X] Remove not used column when saving an invoice from POS

- [X] Deny access to users who are not sellers and sellers who are not approved